### PR TITLE
updated cli tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,14 @@ cd t3-chomper
 pip install -e . 
 ```
 
-You can then parse files from the T3 instrument using the CLI
+You can then parse file(s) from the T3 instrument using the CLI
 
 ```bash
-t3pka --t3-file my_instrument_file.t3
+t3_extract <file or path> --protocol pka --output pka_output.csv
 ```
 
-You can also parse a folder's worth of files
+Or generate CSV import files to create a pka experiment:
 
 ```bash
-t3pka --t3-dir my_directory
+t3_gencsv --regi <registration file> --pka <estimated pka file> --protocol pka --output <pka_experiment_dir>
 ```
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dev = [
 ]
 
 [tool.poetry.scripts]
-t3pka = "t3_chomper.t3_extractor:pka"
+t3r_extract = "t3_chomper.t3_extractor:t3r_extract"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dev = [
 ]
 
 [tool.poetry.scripts]
-t3r_extract = "t3_chomper.t3_extractor:t3r_extract"
+t3_extract = "t3_chomper.t3_extractor:t3_extract"
+t3_gencsv = "t3_chomper.csv_generator:t3_gencsv"
 
 [build-system]
 requires = ["poetry-core"]

--- a/t3_chomper/csv_generator.py
+++ b/t3_chomper/csv_generator.py
@@ -1,0 +1,28 @@
+"""CLI for generating CSV import files for SiriusT3 instrument"""
+
+import click
+from io import StringIO
+
+from t3_chomper.formatters import (
+    generate_registration_pka_file,
+    TrayFormat,
+)
+
+
+@click.command()
+@click.argument(
+    "--regi",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
+)
+@click.argument(
+    "--pka", type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True)
+)
+@click.argument("--output", type=click.Path(exists=False))
+@click.option("--protocol", type=click.Choice(TrayFormat, case_sensitive=False))
+def t3_gencsv(protocol, regi, pka, output):
+    click.echo(f"Generating {protocol} CSV for import")
+    merged_df = generate_registration_pka_file(registration_csv=regi, pka_csv=pka)
+    buffer = StringIO(merged_df.to_csv(None, index=False))
+    formatter = protocol.value(input_csv=buffer)
+    click.echo(f"Found {formatter.num_samples} samples with estimated pKa values.")
+    formatter.generate_csv_files(output_dir=output)

--- a/t3_chomper/csv_generator.py
+++ b/t3_chomper/csv_generator.py
@@ -14,13 +14,17 @@ from t3_chomper.formatters import (
     "--regi",
     required=True,
     type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
+    help="Registration CSV file with sample information",
 )
 @click.option(
     "--pka",
     required=True,
     type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
+    help="CSV file with formatted pKa estimates",
 )
-@click.option("--output", required=True, type=click.Path(exists=False))
+@click.option(
+    "--output", required=True, type=click.Path(exists=False), help="Output directory"
+)
 @click.option(
     "--protocol", required=True, type=click.Choice(TrayFormat, case_sensitive=False)
 )

--- a/t3_chomper/csv_generator.py
+++ b/t3_chomper/csv_generator.py
@@ -10,15 +10,20 @@ from t3_chomper.formatters import (
 
 
 @click.command()
-@click.argument(
+@click.option(
     "--regi",
+    required=True,
     type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
 )
-@click.argument(
-    "--pka", type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True)
+@click.option(
+    "--pka",
+    required=True,
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
 )
-@click.argument("--output", type=click.Path(exists=False))
-@click.option("--protocol", type=click.Choice(TrayFormat, case_sensitive=False))
+@click.option("--output", required=True, type=click.Path(exists=False))
+@click.option(
+    "--protocol", required=True, type=click.Choice(TrayFormat, case_sensitive=False)
+)
 def t3_gencsv(protocol, regi, pka, output):
     click.echo(f"Generating {protocol} CSV for import")
     merged_df = generate_registration_pka_file(registration_csv=regi, pka_csv=pka)

--- a/t3_chomper/extractors.py
+++ b/t3_chomper/extractors.py
@@ -89,9 +89,12 @@ class BaseT3RExtractor:
             raise ValueError("Input file is not the expected assay type")
 
     def _load_document(self):
-        with open(self.filename, "rb") as fin:
-            self._doc = xmltodict.parse(fin)
-            logger.info(f"Loaded {self.filename}")
+        try:
+            with open(self.filename, "rb") as fin:
+                self._doc = xmltodict.parse(fin)
+                logger.info(f"Loaded {self.filename}")
+        except Exception as e:
+            logger.error(f"Error loading file: {self.filename}: {e}")
 
     @property
     def filename(self) -> str:
@@ -129,6 +132,22 @@ class UVMetricPKaT3RExtractor(BaseT3RExtractor):
     """
 
     EXPECTED_ASSAY_CATEGORY = AssayCategory.PKA
+
+    @property
+    def result_dict(self) -> dict:
+        """
+        Return a result summary as a dict
+        """
+        return {
+            "filename": self.filename,
+            "sample": self.sample_name,
+            "assay_name": self.assay_name,
+            "assay_quality": self.assay_quality,
+            "pka": self.mean_pka_values,
+            "std": self.mean_pka_std_values,
+            "ionic_strength": self.mean_pka_ionic_strengths,
+            "temp": self.mean_pka_temperatures,
+        }
 
     @cached_property
     def _mean_dpas_result(self) -> dict:
@@ -177,6 +196,19 @@ class LogPT3RExtractor(BaseT3RExtractor):
     """
 
     EXPECTED_ASSAY_CATEGORY = AssayCategory.LOGP
+
+    @property
+    def result_dict(self) -> dict:
+        """Return parsed results as a dict"""
+        return {
+            "filename": self.filename,
+            "sample": self.sample_name,
+            "assay_name": self.assay_name,
+            "assay_quality": self.assay_quality,
+            "logp": self.logp_result.value,
+            "rmsd": self.logp_result.rmsd,
+            "solvent": self.logp_solvent,
+        }
 
     @cached_property
     def logp_result(self) -> LogPResult:

--- a/t3_chomper/formatters.py
+++ b/t3_chomper/formatters.py
@@ -1,3 +1,4 @@
+import enum
 import pathlib
 
 import pandas as pd
@@ -205,3 +206,12 @@ class LogPGenerator(SiriusT3CSVGenerator):
             lines.append("Clean Up")
             lines.append("Clean Up")
         return "\n".join(lines)
+
+
+class TrayFormat(enum.Enum):
+    """
+    Enum of defined tray formats
+    """
+
+    FastUVPSKA = FastUVPSKAGenerator
+    LogP = LogPGenerator

--- a/t3_chomper/formatters.py
+++ b/t3_chomper/formatters.py
@@ -31,9 +31,21 @@ def generate_registration_pka_file(
     """
 
     regi_df = pd.read_csv(registration_csv)
-    if registration_id_col not in regi_df.columns:
-        raise ValueError(
-            f"Expected column {registration_id_col} is missing in {registration_csv}"
+    regi_required_columns = [
+        registration_id_col,
+        "Registry Number",
+        "Batch Name",
+        "Well",
+        "MW",
+    ]
+    for col in regi_required_columns:
+        if col not in regi_df.columns:
+            raise ValueError(
+                f"Expected column {registration_id_col} is missing in {registration_csv}"
+            )
+    if "batch_sample" not in regi_df.columns:
+        regi_df["batch_sample"] = regi_df.apply(
+            lambda x: f"""{x["Registry Number"]}-{x["Batch Name"]}""", axis=1
         )
 
     pka_df = pd.read_csv(pka_csv)
@@ -88,8 +100,9 @@ class SiriusT3CSVGenerator:
 
     def _load_input_file(self) -> pd.DataFrame:
         df = pd.read_csv(self._input_csv)
-        if self._pkas_col not in df.columns:
-            raise ValueError(f"Column {self._pkas_col} not found in {self._input_csv}")
+        for col in [self._pkas_col, self._sample_id_col]:
+            if col not in df.columns:
+                raise ValueError(f"""Column "{col}" not found in {self._input_csv}""")
         missing_pkas_count = df[self._pkas_col].isna().sum()
         if missing_pkas_count:
             missing_row_ids = df[df[self._pkas_col].isna()][self._sample_id_col]
@@ -110,8 +123,8 @@ class SiriusT3CSVGenerator:
                     [
                         f"{getattr(row, self._sample_id_col)}",
                         f"{getattr(row, self._pkas_col).rstrip(',')}",
-                        f"""SYM,{getattr(row, "well")}""",
-                        f"""MW,{getattr(row, "mw")}""",
+                        f"""SYM,{getattr(row, "Well")}""",
+                        f"""MW,{getattr(row, "MW")}""",
                     ]
                 )
             )

--- a/t3_chomper/parsers.py
+++ b/t3_chomper/parsers.py
@@ -30,7 +30,6 @@ class CaseInsensitiveStrEnum(enum.StrEnum):
 class AssayCategory(CaseInsensitiveStrEnum):
     "Assay categories that we consider"
 
-    NULL = enum.auto()
     PKA = enum.auto()
     LOGP = enum.auto()
 
@@ -78,7 +77,7 @@ class BaseT3RParser:
     This base class defines properties common to all t3r result files.
     """
 
-    EXPECTED_ASSAY_CATEGORY = AssayCategory.NULL
+    EXPECTED_ASSAY_CATEGORY = None
 
     def __init__(self, filename: str) -> None:
         self._filename = filename

--- a/t3_chomper/parsers.py
+++ b/t3_chomper/parsers.py
@@ -61,7 +61,7 @@ class LogPResult:
     rmsd: float
 
 
-def get_assay_category(filename: str) -> AssayCategory:
+def get_assay_category(filename: Union[str, pathlib.Path]) -> AssayCategory:
     """Utility function to quickly get the assay category for a provided t3r file"""
 
     with open(filename) as fin:
@@ -82,9 +82,7 @@ class BaseT3RParser:
     EXPECTED_ASSAY_CATEGORY = None
 
     def __init__(self, filename: Union[str, pathlib.Path]) -> None:
-        self._filename = (
-            filename.name if isinstance(filename, pathlib.Path) else filename
-        )
+        self._filename = pathlib.Path(filename)
         self._doc: dict = {}
         self._load_document()
 
@@ -100,7 +98,7 @@ class BaseT3RParser:
             logger.error(f"Error loading file: {self.filename}: {e}")
 
     @property
-    def filename(self) -> str:
+    def filename(self) -> pathlib.Path:
         return self._filename
 
     @property
@@ -142,7 +140,7 @@ class UVMetricPKaT3RParser(BaseT3RParser):
         Return a result summary as a dict
         """
         return {
-            "filename": self.filename,
+            "filename": self.filename.name,
             "sample": self.sample_name,
             "assay_name": self.assay_name,
             "assay_quality": self.assay_quality,
@@ -206,7 +204,7 @@ class LogPT3RParser(BaseT3RParser):
     def result_dict(self) -> dict:
         """Return parsed results as a dict"""
         return {
-            "filename": self.filename,
+            "filename": self.filename.name,
             "sample": self.sample_name,
             "assay_name": self.assay_name,
             "assay_quality": self.assay_quality,

--- a/t3_chomper/parsers.py
+++ b/t3_chomper/parsers.py
@@ -71,9 +71,9 @@ def get_assay_category(filename: str) -> AssayCategory:
         raise ValueError("Could not determine assay category")
 
 
-class BaseT3RExtractor:
+class BaseT3RParser:
     """
-    Base class for extracting data from T3R files.
+    Base class for parsing data from T3R files.
     Subclasses can be defined for specific experimental protocols.
     This base class defines properties common to all t3r result files.
     """
@@ -126,7 +126,7 @@ class BaseT3RExtractor:
         return self._doc["DirectControlAssayResultsFile"]["Summary"]["SampleName"]
 
 
-class UVMetricPKaT3RExtractor(BaseT3RExtractor):
+class UVMetricPKaT3RParser(BaseT3RParser):
     """
     Class to handle results file from pKa Experiment
     """
@@ -190,7 +190,7 @@ class UVMetricPKaT3RExtractor(BaseT3RExtractor):
         )
 
 
-class LogPT3RExtractor(BaseT3RExtractor):
+class LogPT3RParser(BaseT3RParser):
     """
     Class to handle results file from a LogP experiment
     """

--- a/t3_chomper/t3_extractor.py
+++ b/t3_chomper/t3_extractor.py
@@ -66,7 +66,6 @@ class FileOrPathExtractor:
 @click.option(
     "--output",
     type=click.Path(exists=False, file_okay=True),
-    default="t3r_results.csv",
 )
 @click.option(
     "--protocol", required=True, type=click.Choice(AssayCategory, case_sensitive=False)
@@ -80,5 +79,9 @@ def t3_extract(path, output, protocol):
         df = extractor.parse_logp_files()
     else:
         raise ValueError(f"Unknown Assay category: {protocol}")
-    logger.info(f"Finished parsing, writing to {output}")
-    df.to_csv(output, index=False)
+    if output:
+        logger.info(f"Finished parsing, writing to {output}")
+        df.to_csv(output, index=False)
+    else:
+        logger.info(f"No output file provided, writing to stdout.")
+        click.echo(df.to_csv(index=False))

--- a/t3_chomper/t3_extractor.py
+++ b/t3_chomper/t3_extractor.py
@@ -7,71 +7,62 @@ from typing import Union
 import click
 import pandas as pd
 
-from t3_chomper.extractors import UVMetricPKaT3RExtractor
+from t3_chomper.extractors import (
+    UVMetricPKaT3RExtractor,
+    LogPT3RExtractor,
+    AssayCategory,
+)
 from t3_chomper.logger import get_logger
 
 logger = get_logger(__name__)
 
 
-def parse_t3_pka_xml(file: Union[str, Path]) -> tuple:
+class FileOrPathExtractor:
     """
-    Read XML file from the Sirus T3 machine and extract pKa data.
-
-    Returns:
-        Tuple of (pka, stdev, ionic_strength, temp)
+    Class to extract data from one or more t3r result files.
     """
-    extractor = UVMetricPKaT3RExtractor(file)
 
-    pka = extractor.mean_pka_values
-    stdev = extractor.mean_pka_std_values
-    ionic_strength = extractor.mean_pka_ionic_strengths
-    temp = extractor.mean_pka_temperatures
+    def __init__(
+        self,
+        t3_dir: Union[str, None] = None,
+        t3_file: Union[str, None] = None,
+    ):
+        if (t3_dir is None and t3_file is None) or (t3_dir and t3_file):
+            raise ValueError("Provide either t3_dir or t3_file, but not both.")
 
-    return pka, stdev, ionic_strength, temp
+        if t3_dir:
+            self._t3_files = glob.glob(f"{t3_dir}/*.t3r")
+            if not self._t3_files:
+                raise FileNotFoundError(f"No .t3r files found in directory: {t3_dir}")
+        else:
+            self._t3_files = [t3_file]
 
+    def _parse_files(self, assay_category: AssayCategory) -> pd.DataFrame:
+        """ """
+        rows = []
+        for file in self._t3_files:
+            logger.debug(f"Parsing T3R XML file: {file}")
+            if assay_category == AssayCategory.PKA:
+                pka_parser = UVMetricPKaT3RExtractor(file)
+                results = pka_parser.result_dict
+            elif assay_category == AssayCategory.LOGP:
+                logp_parser = LogPT3RExtractor(file)
+                results = logp_parser.result_dict
+            else:
+                raise ValueError(f"Unknown assay category: {assay_category}")
+            results["file"] = Path(file).name
+            rows.append(results)
+        df = pd.DataFrame(rows)
+        return df
 
-def parse_pkas(
-    t3_dir: Union[str, None] = None, t3_file: Union[str, None] = None
-) -> pd.DataFrame:
-    """
-    Parse one or multiple .t3 files from directory or single file into a DataFrame.
+    def parse_pka_files(self):
+        return self._parse_files(AssayCategory.PKA)
 
-    Only one of t3_dir or t3_file must be provided.
-    """
-    if (t3_dir is None and t3_file is None) or (t3_dir and t3_file):
-        raise ValueError("Provide either t3_dir or t3_file, but not both.")
-
-    if t3_dir:
-        t3_files = glob.glob(f"{t3_dir}/*.t3r")
-        if not t3_files:
-            raise FileNotFoundError(f"No .t3r files found in directory: {t3_dir}")
-    else:
-        t3_files = [t3_file]
-
-    rows = []
-    for file in t3_files:
-        logger.debug(f"Parsing T3 XML file: {file}")
-        try:
-            pka, stdev, ionic_strength, temp = parse_t3_pka_xml(file)
-        except Exception as e:
-            logger.error(f"Error parsing file {file}: {e}")
-            continue
-
-        rows.append(
-            {
-                "file": Path(file).name,
-                "pka": pka,
-                "stdev": stdev,
-                "ionic_strength": ionic_strength,
-                "temperature": temp,
-            }
-        )
-
-    df = pd.DataFrame(rows)
-    return df
+    def parse_logp_files(self):
+        return self._parse_files(AssayCategory.LOGP)
 
 
-@click.command()
+@click.group()
 @click.option(
     "--t3-dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True, readable=True),
@@ -89,15 +80,33 @@ def parse_pkas(
     type=click.Path(exists=False, file_okay=True),
     default="pka_results.csv",
 )
+def t3r_extract():
+    click.echo(f"Extracting data from t3r files.")
+
+
+@t3r_extract.command()
 def pka(t3_dir, t3_file, output_csv):
     """
-    CLI entry point for parsing T3 pKa XML files and exporting to CSV.
+    Parse T3R pKa XML files and export to CSV.
     """
     logger.info("Running T3 pKa parsing")
-    df = parse_pkas(t3_dir, t3_file)
+    extractor = FileOrPathExtractor(t3_dir=t3_dir, t3_file=t3_file)
+    df = extractor.parse_pka_files()
+    logger.info(f"Finished parsing, writing to {output_csv}")
+    df.to_csv(output_csv, index=False)
+
+
+@t3r_extract.command()
+def logp(t3_dir, t3_file, output_csv):
+    """
+    Parse T3R logp XML files and export to CSV.
+    """
+    logger.info("Running T3 logp parsing")
+    extractor = FileOrPathExtractor(t3_dir=t3_dir, t3_file=t3_file)
+    df = extractor.parse_logp_files()
     logger.info(f"Finished parsing, writing to {output_csv}")
     df.to_csv(output_csv, index=False)
 
 
 if __name__ == "__main__":
-    pka()
+    pass

--- a/t3_chomper/t3_extractor.py
+++ b/t3_chomper/t3_extractor.py
@@ -7,9 +7,9 @@ from typing import Union
 import click
 import pandas as pd
 
-from t3_chomper.extractors import (
-    UVMetricPKaT3RExtractor,
-    LogPT3RExtractor,
+from t3_chomper.parsers import (
+    UVMetricPKaT3RParser,
+    LogPT3RParser,
     AssayCategory,
 )
 from t3_chomper.logger import get_logger
@@ -43,10 +43,10 @@ class FileOrPathExtractor:
         for file in self._t3_files:
             logger.debug(f"Parsing T3R XML file: {file}")
             if assay_category == AssayCategory.PKA:
-                pka_parser = UVMetricPKaT3RExtractor(file)
+                pka_parser = UVMetricPKaT3RParser(file)
                 results = pka_parser.result_dict
             elif assay_category == AssayCategory.LOGP:
-                logp_parser = LogPT3RExtractor(file)
+                logp_parser = LogPT3RParser(file)
                 results = logp_parser.result_dict
             else:
                 raise ValueError(f"Unknown assay category: {assay_category}")

--- a/t3_chomper/t3_extractor.py
+++ b/t3_chomper/t3_extractor.py
@@ -68,7 +68,9 @@ class FileOrPathExtractor:
     type=click.Path(exists=False, file_okay=True),
     default="t3r_results.csv",
 )
-@click.option("--protocol", type=click.Choice(AssayCategory, case_sensitive=False))
+@click.option(
+    "--protocol", required=True, type=click.Choice(AssayCategory, case_sensitive=False)
+)
 def t3_extract(path, output, protocol):
     click.echo(f"Extracting data from t3r files.")
     extractor = FileOrPathExtractor(path=path)

--- a/t3_chomper/t3_extractor.py
+++ b/t3_chomper/t3_extractor.py
@@ -62,6 +62,7 @@ class FileOrPathExtractor:
     "path",
     type=click.Path(exists=True, file_okay=True, dir_okay=True, readable=True),
     default=None,
+    help="t3r result file or directory",
 )
 @click.option(
     "--output",

--- a/t3_chomper/t3_extractor.py
+++ b/t3_chomper/t3_extractor.py
@@ -62,7 +62,6 @@ class FileOrPathExtractor:
     "path",
     type=click.Path(exists=True, file_okay=True, dir_okay=True, readable=True),
     default=None,
-    help="t3r result file or directory",
 )
 @click.option(
     "--output",

--- a/t3_chomper/t3_extractor.py
+++ b/t3_chomper/t3_extractor.py
@@ -46,7 +46,6 @@ class FileOrPathExtractor:
                 results = logp_parser.result_dict
             else:
                 raise ValueError(f"Unknown assay category: {assay_category}")
-            results["file"] = Path(file).name
             rows.append(results)
         df = pd.DataFrame(rows)
         return df
@@ -67,10 +66,10 @@ class FileOrPathExtractor:
 @click.option(
     "--output",
     type=click.Path(exists=False, file_okay=True),
-    default="pka_results.csv",
+    default="t3r_results.csv",
 )
 @click.option("--protocol", type=click.Choice(AssayCategory, case_sensitive=False))
-def t3_extract(path, output_csv, protocol):
+def t3_extract(path, output, protocol):
     click.echo(f"Extracting data from t3r files.")
     extractor = FileOrPathExtractor(path=path)
     if protocol == AssayCategory.PKA:
@@ -79,5 +78,5 @@ def t3_extract(path, output_csv, protocol):
         df = extractor.parse_logp_files()
     else:
         raise ValueError(f"Unknown Assay category: {protocol}")
-    logger.info(f"Finished parsing, writing to {output_csv}")
-    df.to_csv(output_csv, index=False)
+    logger.info(f"Finished parsing, writing to {output}")
+    df.to_csv(output, index=False)


### PR DESCRIPTION
introduces 2 cli tools: 
* t3_extract for extracting data from one or more t3r files. Simplifies arguments to just take a path which can be a file or directory of t3r files
* t3_gencsv for generating csv import files to set up experiments

minor changes:
* updated readme
* rename 'extractor'  classes to 'parser' classes
* ensure compatibility with python3.9 (remove match constructs, some typing operators, etc.)