### PR TITLE
Error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "t3-chomper"
-version = "0.1.5"
+version = "0.1.6"
 description = "Parse pKa data from Sirus T3 XML files"
 authors = ["hugo.macdermott-opeskin@omsf.io", "johncfaver@gmail.com"]
 

--- a/t3_chomper/formatters.py
+++ b/t3_chomper/formatters.py
@@ -101,14 +101,18 @@ def generate_registration_pka_file(
         columns={pka_id_col: registration_id_col}
     )
 
+    # left join on regi file, unmatched rows will have null pKa values
     merged_df = pd.merge(regi_df, pka_df, how="left", on=registration_id_col)
 
+    # Warn if there are rows with unmatched pKa values
     missing_row_count = merged_df[pka_pkas_col].isna().sum()
     if missing_row_count:
         missing_row_ids = merged_df[merged_df[pka_pkas_col].isna()][registration_id_col]
-        raise ValueError(
-            f"{missing_row_count} rows have missing data: {missing_row_ids}"
+        logger.warning(
+            f"{missing_row_count} rows have missing pKa data and will be dropped: {missing_row_ids}"
         )
+    # Drop rows with no pKa data
+    merged_df.dropna(subset=pka_pkas_col, inplace=True)
 
     return merged_df
 

--- a/t3_chomper/t3_extractor.py
+++ b/t3_chomper/t3_extractor.py
@@ -22,54 +22,97 @@ class FileOrPathExtractor:
     """
 
     def __init__(self, path: Union[str, Path]):
-        path = Path(path)
-        if path.is_dir():
-            self._t3_files = list(path.glob("*.t3r"))
+        """
+        Args:
+            path: either string or path pointing to a single file or directory of t3r files
+        """
+        self.path = Path(path)
+        self.num_files = None
+        self.rows = []
+        self.failed_filenames = []
+
+        if self.path.is_dir():
+            self._t3_files = list(self.path.glob("*.t3r"))
             if not self._t3_files:
                 raise FileNotFoundError(f"No .t3r files found in directory: {path}")
-            num_files = len(self._t3_files)
-            logger.info(f"Found {num_files} t3r results files.")
+            self.num_files = len(self._t3_files)
+            logger.info(f"Found {self.num_files} t3r results files.")
         else:
             self._t3_files = [path]
+            self.num_files = 1
             logger.info(f"Found 1 t3r result file.")
 
-    def parse_pka_files(self) -> pd.DataFrame:
+    @property
+    def num_succeeded(self) -> int:
+        """
+        Number of successfully parsed files
+        """
+        return len(self.rows)
+
+    @property
+    def num_failed(self) -> int:
+        """
+        Number of filenames that failed parsing
+        """
+        return len(self.failed_filenames)
+
+    def parse_pka_files(self) -> None:
         """
         Parse pKa result data files and return a dataframe of parsed results
         """
-        rows = []
-        failed_files = []
         for file in self._t3_files:
             logger.debug(f"Parsing T3R XML file: {file}")
             try:
                 pka_parser = UVMetricPKaT3RParser(file)
                 # Get results as list of dict objects per pKa
                 results_list = pka_parser.result_list
-                rows.extend(results_list)
+                self.rows.extend(results_list)
             except Exception as e:
                 logger.error(f"Error parsing data: {e}")
-                failed_files.append(file)
-        df = pd.DataFrame(rows)
-        return df
+                self.failed_filenames.append(file)
 
-    def parse_logp_files(self) -> pd.DataFrame:
+    def parse_logp_files(self) -> None:
         """
         Parse logp result data files and return a dataframe of parsed results
         """
-        rows = []
-        failed_files = []
         for file in self._t3_files:
             logger.debug(f"Parsing T3R XML file: {file}")
             try:
                 logp_parser = LogPT3RParser(file)
                 # Get logp result as a dict object
                 result = logp_parser.result_dict
-                rows.append(result)
+                self.rows.append(result)
             except Exception as e:
                 logger.error(f"Error parsing data: {e}")
-                failed_files.append(file)
-        df = pd.DataFrame(rows)
-        return df
+                self.failed_filenames.append(file)
+
+    def get_results_df(self) -> pd.DataFrame:
+        """
+        Return results as a dataframe
+        """
+        if len(self.rows) == 0:
+            logger.error(f"No parsed results")
+        return pd.DataFrame(self.rows)
+
+    def write_results_csv(self, filename: Union[str, Path]) -> None:
+        """
+        Write parsed results to csv
+        Args:
+            filename: filename for the output file
+        """
+        df = self.get_results_df()
+        df.to_csv(filename, index=False)
+
+    def write_failed_csv(self, filename: Union[str, Path]) -> None:
+        """
+        Write a csv file with a column of filenames which failed to parse
+        Args:
+            filename: filename for the failed filenames file
+        """
+        if len(self.failed_filenames) == 0:
+            logger.info(f"No files failed to parse")
+        df = pd.DataFrame({"failed_filenames": self.failed_filenames})
+        df.to_csv(filename, index=False)
 
 
 @click.command()
@@ -88,16 +131,23 @@ class FileOrPathExtractor:
 def t3_extract(path, output, protocol):
     click.echo(f"Extracting data from t3r files.")
     extractor = FileOrPathExtractor(path=path)
+
     if protocol == AssayCategory.PKA:
-        df = extractor.parse_pka_files()
+        extractor.parse_pka_files()
     elif protocol == AssayCategory.LOGP:
-        df = extractor.parse_logp_files()
+        extractor.parse_logp_files()
     else:
         raise ValueError(f"Unknown Assay category: {protocol}")
 
     if output:
         logger.info(f"Finished parsing, writing to {output}")
-        df.to_csv(output, index=False)
+        extractor.write_results_csv(output)
+
+        failed_filenames_loc = Path(output).parent / "failed_filenames.csv"
+        extractor.write_failed_csv(failed_filenames_loc)
     else:
         logger.info(f"No output file provided, writing to stdout.")
+        df = extractor.get_results_df()
         click.echo(df.to_csv(index=False))
+        if extractor.num_failed > 0:
+            logger.error(f"{extractor.num_failed} files failed to parse.")

--- a/t3_chomper/t3_extractor.py
+++ b/t3_chomper/t3_extractor.py
@@ -38,7 +38,7 @@ class FileOrPathExtractor:
             self.num_files = len(self._t3_files)
             logger.info(f"Found {self.num_files} t3r results files.")
         else:
-            self._t3_files = [path]
+            self._t3_files = [self.path]
             self.num_files = 1
             logger.info(f"Found 1 t3r result file.")
 

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -11,7 +11,10 @@ def test_pka_extractor(pka_result_filename):
     assert isinstance(x._t3_files, list)
     assert len(x._t3_files) == 1
     assert x._t3_files[0] == pathlib.Path(pka_result_filename)
-    df = x.parse_pka_files()
+    x.parse_pka_files()
+    df = x.get_results_df()
+    assert x.num_succeeded == 1
+    assert x.num_failed == 0
     assert isinstance(df, pd.DataFrame)
     assert all(
         col in df.columns
@@ -39,8 +42,11 @@ def test_logp_extractor(logp_result_filename):
     assert isinstance(x._t3_files, list)
     assert len(x._t3_files) == 1
     assert x._t3_files[0] == pathlib.Path(logp_result_filename)
-    df = x.parse_logp_files()
+    x.parse_logp_files()
+    df = x.get_results_df()
     assert isinstance(df, pd.DataFrame)
+    assert x.num_succeeded == 1
+    assert x.num_failed == 0
     assert all(
         col in df.columns
         for col in [


### PR DESCRIPTION
1. Write filenames that failed to parse into "failed_filenames.csv"
2. when parsing a directory of files, log errors rather than raise exceptions
3. when merging regi/pka files, warn about null pKas (no matches in pKa data file) and drop them rather than raise exception