### PR TITLE
enable using a filter file, update column handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 Parse data from [Pion Sirius T3 instrument](https://www.pion-inc.com/solutions/products/siriust3) XML files
 
-
 # WARNING HIGHLY WIP 
-
 
 # Instructions
 
@@ -51,19 +49,20 @@ There are several defined experimental tray layouts which can be listed by viewi
 t3_gencsv --help
 ```
 
-The **registration file** should have the following columns:
+The **registration file** should have the following columns (column names are case-insensitive):
 
-| Column          | Description                            |
-|-----------------|----------------------------------------|
-| ID              | compound ID (must match pKa data file) |
-| Registry Number | compound name in registry              |
-| Batch Name      | Name/number of compound batch          |
-| Well            | well in plate                          |
-| MW              | molecular weight                       |
-| FW              | formula weight                         | 
-| mg              | mass in mg                             |
+| Column                       | Description                                   |
+|------------------------------|-----------------------------------------------|
+| sample                       | compound/sample ID (must match pKa data file) |
+| well                         | well in plate                                 |
+| mw                           | molecular weight                              |
+| fw                           | formula weight                                | 
+| mg                           | mass in mg                                    |
+| registry number *(optional)* | compound name in registry                     |
+| batch name *(optional)*      | Name/number of compound batch                 |
 
-
+If the **sample** column is absent, but there are columns for **registry number** and **batch name**, they will be 
+joined with a hyphen to produce a new "sample" column.
 
 The **pKa data file** can be in one of two formats: 
 
@@ -74,7 +73,7 @@ It uses the same comma-separated format that the T3 instrument uses.
 
 | Column           | Description                                                                         |
 |------------------|-------------------------------------------------------------------------------------|
-| vendor_id        | compound ID (must match registration file)                                          |
+| sample           | compound/sample ID (must match registration file)                                   |
 | reformatted_pkas | comma-separated list of pKas and types in ascending order: e.g. "ACID,2.5,BASE,9.3" |
 
 ### Long pKa data file format:
@@ -82,12 +81,19 @@ It uses the same comma-separated format that the T3 instrument uses.
 The long format includes one row for each pKa. 
 Compounds with multiple pKas will appear in multiple rows.
 
-| Column    | Description                                |
-|-----------|--------------------------------------------|
-| vendor_id | compound ID (must match registration file) |
-| pka_value | value of pka                               |
-| pka_type  | type of pka ("acid" or "base")             |
+| Column    | Description                                       |
+|-----------|---------------------------------------------------|
+| sample    | compound/sample ID (must match registration file) |
+| pka_value | value of pka                                      |
+| pka_type  | type of pka ("acid" or "base")                    |
 
+
+### Filtering/Limiting Entries
+
+One can limit the entries that are used in the experiment by filtering samples in the regi file 
+by including a filter file with the `--filter-file` argument. The filter file just needs one column
+**sample** that matches samples in the regi file. Only samples found in the filter file will progress
+to subsequent steps for generating experiment files.
 
 ### Available experiment layouts
 
@@ -101,9 +107,14 @@ Compounds with multiple pKas will appear in multiple rows.
 
 Files for each tray will be generated in the output directory provided with the --output argument.
 
+### Examples 
+
 ```bash
 # Generate csv experiment import files with fastuvpska format
 t3_gencsv --regi <registration file> --pka <pKa data file> --protocol fastuvpska --output <new_pka_experiment_dir>
 # Generate csv experiment import files with logp format
 t3_gencsv --regi <registration file> --pka <pKa data file> --protocol logp --output <new_logp_experiment_dir>
+# Generate csv experiment import files with phmetric tray format and only include samples listed in the filter file
+t3_gencsv --regi <registration file> --filter-file <filter_file> --pka <pKa data file> --protocol phmetric --output <new_logp_experiment_dir>
+
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "t3-chomper"
-version = "0.1.6"
+version = "0.1.7"
 description = "Parse pKa data from Sirus T3 XML files"
 authors = ["hugo.macdermott-opeskin@omsf.io", "johncfaver@gmail.com"]
 

--- a/t3_chomper/csv_generator.py
+++ b/t3_chomper/csv_generator.py
@@ -32,7 +32,7 @@ from t3_chomper.formatters import (
     "--sample-col",
     required=False,
     default="sample",
-    type="str",
+    type=str,
     help="Name of sample/ID column. Used for joining across files.",
 )
 @click.option(

--- a/t3_chomper/csv_generator.py
+++ b/t3_chomper/csv_generator.py
@@ -23,15 +23,45 @@ from t3_chomper.formatters import (
     help="CSV file with formatted pKa estimates",
 )
 @click.option(
+    "--filter-file",
+    required=False,
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
+    help="File to limit entries from the regi file. Only samples included in the filter file will be considered.",
+)
+@click.option(
+    "--sample-col",
+    required=False,
+    default="sample",
+    type="str",
+    help="Name of sample/ID column. Used for joining across files.",
+)
+@click.option(
     "--output", required=True, type=click.Path(exists=False), help="Output directory"
 )
 @click.option(
     "--protocol", required=True, type=click.Choice(TrayFormat, case_sensitive=False)
 )
-def t3_gencsv(protocol, regi, pka, output):
+def t3_gencsv(regi, pka, filter_file, sample_col, output, protocol):
+    """
+    Tool for generating experiment files for SiriusT3 instrument.
+    Expects a registration ("regi") file with sample information, a pKa file with estimated pKas,
+    a protocol, and an output location.
+    Items from the regi file with matching items in the pKa file (and the filter file, if provided) will be
+    used to generate experiment import files. These files will be written to the output location.
+    Matching is based on the column named "sample", unless another name is provided with the --sample-col argument.
+    The pKa file is expected to be in one of two formats:
+        1) a "short" format with a column named "reformatted_pkas" that are formatted for the SiriusT3 instrumnet as comma-separated values, e.g.,
+            "ACID,4.5,BASE,10.5"
+    or  2) a "long" format with one row per pKa, and separate columns named "pka_value" and "pka_type"
+    """
     click.echo(f"Generating {protocol} CSV for import")
-    merged_df = generate_registration_pka_file(registration_csv=regi, pka_csv=pka)
+    merged_df = generate_registration_pka_file(
+        registration_csv=regi,
+        pka_csv=pka,
+        filter_file=filter_file,
+        sample_col=sample_col,
+    )
     buffer = StringIO(merged_df.to_csv(None, index=False))
-    formatter = protocol.value(input_csv=buffer)
+    formatter = protocol.value(input_csv=buffer, sample_id_col=sample_col)
     click.echo(f"Found {formatter.num_samples} samples with estimated pKa values.")
     formatter.generate_csv_files(output_dir=output)

--- a/t3_chomper/formatters.py
+++ b/t3_chomper/formatters.py
@@ -1,5 +1,6 @@
 import enum
 import pathlib
+from typing import Union
 
 import pandas as pd
 
@@ -32,6 +33,7 @@ def convert_long_pka_df(
     """
     for col in [id_col, pka_col, pka_type_col]:
         if col not in long_df.columns:
+            logger.error(f"Missing expected column {col} ")
             raise ValueError(f"Missing expected column {col} ")
     # Sort by compound and ascending pKa value
     long_df.sort_values([id_col, pka_col], inplace=True)
@@ -51,9 +53,8 @@ def convert_long_pka_df(
 def generate_registration_pka_file(
     registration_csv: str,
     pka_csv: str,
-    registration_id_col: str = "ID",
-    pka_id_col: str = "vendor_id",
-    pka_pkas_col: str = "reformatted_pkas",
+    filter_file: Union[str, None] = None,
+    sample_col: str = "sample",
 ) -> pd.DataFrame:
     """
     From a CSV of registration data and a CSV of estimated pKa data, return a merged dataframe
@@ -62,57 +63,76 @@ def generate_registration_pka_file(
         registration_csv: registration data file. Expects compounds to be annotated with "ID" column
         pka_csv: pKa estimate data file. Expected compounds to be annotated with a "vendor_id" column, and
             pKa estimates formatted for Pion Sirius T3 input files under a column named "reformatted_pkas"
-        registration_id_col: name of the column in the registration file with compound IDs
-        pka_id_col: name of the column in the pKa data file with compound IDs
-        pka_pkas_col: name of the column in the pKa data file with pKa data
-
+        filter_file: file with sample names that should be considered, used to filter a larger regi file.
+        sample_fol: name of column with unique sample names
     Returns:
         Merged dataframe with columns from the registration_csv and the estimated pKa data from the pKa data file
     """
 
     regi_df = pd.read_csv(registration_csv)
+    logger.info(f"Read regi file {registration_csv} with {len(regi_df)} rows.")
+
+    # If sample_col is not present, but registry number and batch name are, construct sample_col
+    if sample_col not in regi_df.columns:
+        if "Registry Number" in regi_df.columns and "Batch Name" in regi_df.columns:
+            regi_df[sample_col] = regi_df.apply(
+                lambda x: f"""{x["Registry Number"]}-{x["Batch Name"]}""", axis=1
+            )
+
+    # Regi file must have sample_col, well and MW columns
     regi_required_columns = [
-        registration_id_col,
-        "Registry Number",
-        "Batch Name",
+        sample_col,
         "Well",
         "MW",
     ]
     for col in regi_required_columns:
         if col not in regi_df.columns:
-            raise ValueError(
-                f"Expected column {registration_id_col} is missing in {registration_csv}"
-            )
-    if "batch_sample" not in regi_df.columns:
-        regi_df["batch_sample"] = regi_df.apply(
-            lambda x: f"""{x["Registry Number"]}-{x["Batch Name"]}""", axis=1
-        )
+            msg = f"Expected column {col} is missing in {registration_csv}"
+            logger.error(msg)
+            raise ValueError(msg)
 
+    # Handle use of filter file to sub-select rows from regi file
+    if filter_file is not None:
+        filter_df = pd.read_csv(filter_file)
+        logger.info(f"Read filter file {filter_file} with {len(filter_df)} rows.")
+        if sample_col not in filter_df:
+            msg = f"Expected column {sample_col} in {filter_file}"
+            logger.error(msg)
+            raise ValueError(msg)
+        regi_df = pd.merge(regi_df, filter_df, how="inner", on=sample_col)
+        num_pass_filter = len(regi_df)
+        if num_pass_filter == 0:
+            msg = f"No matches between regi file and filter file!"
+            logger.error(msg)
+            raise ValueError(msg)
+        logger.info(f"After using filter file, {len(regi_df)} rows remain.")
+
+    # Read pKa file
     pka_df = pd.read_csv(pka_csv)
-    if pka_id_col not in pka_df.columns:
-        raise ValueError(f"Expected column {pka_id_col} is missing in {pka_csv}")
+    if sample_col not in pka_df.columns:
+        raise ValueError(f"Expected column {sample_col} is missing in {pka_csv}")
 
     # If the pKa data file is in the long-format with one row per pKa, then try to reformat
     # to generate a 'short-format' pKa file with one row per compound
-    if pka_pkas_col not in pka_df.columns:
-        pka_df = convert_long_pka_df(pka_df, compound_col=pka_id_col)
+    pkas_col = "reformatted_pkas"
+    if pkas_col not in pka_df.columns:
+        pka_df = convert_long_pka_df(pka_df, id_col=sample_col)
 
-    pka_df = pka_df[[pka_id_col, pka_pkas_col]].rename(
-        columns={pka_id_col: registration_id_col}
-    )
+    pka_df = pka_df[[sample_col, pkas_col]]
 
     # left join on regi file, unmatched rows will have null pKa values
-    merged_df = pd.merge(regi_df, pka_df, how="left", on=registration_id_col)
+    merged_df = pd.merge(regi_df, pka_df, how="left", on=sample_col)
 
     # Warn if there are rows with unmatched pKa values
-    missing_row_count = merged_df[pka_pkas_col].isna().sum()
-    if missing_row_count:
-        missing_row_ids = merged_df[merged_df[pka_pkas_col].isna()][registration_id_col]
+    missing_row_count = merged_df[pkas_col].isna().count()
+    if missing_row_count > 0:
+        missing_row_ids = merged_df[merged_df[pkas_col].isna()][sample_col]
         logger.warning(
             f"{missing_row_count} rows have missing pKa data and will be dropped: {missing_row_ids}"
         )
     # Drop rows with no pKa data
-    merged_df.dropna(subset=pka_pkas_col, inplace=True)
+    merged_df.dropna(subset=pkas_col, inplace=True)
+    logger.info(f"Merged data has {len(merged_df)} rows with pKa data.")
 
     return merged_df
 
@@ -138,7 +158,7 @@ class SiriusT3CSVGenerator:
         self,
         input_csv: str,
         pkas_col: str = "reformatted_pkas",
-        sample_id_col: str = "batch_sample",
+        sample_id_col: str = "sample",
         fw_col: str = "fw",
         mg_col: str = "mg",
         well_col: str = "well",

--- a/t3_chomper/formatters.py
+++ b/t3_chomper/formatters.py
@@ -103,7 +103,7 @@ def generate_registration_pka_file(
             msg = f"Expected column {sample_col} in {filter_file}"
             logger.error(msg)
             raise ValueError(msg)
-        regi_df = pd.merge(regi_df, filter_df, how="inner", on=sample_col)
+        regi_df = regi_df[regi_df[sample_col].isin(filter_df[sample_col])]
         num_pass_filter = len(regi_df)
         if num_pass_filter == 0:
             msg = f"No matches between regi file and filter file!"

--- a/t3_chomper/formatters.py
+++ b/t3_chomper/formatters.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 import enum
 import pathlib
 from typing import Union
@@ -140,7 +141,7 @@ def generate_registration_pka_file(
     return merged_df
 
 
-class SiriusT3CSVGenerator:
+class SiriusT3CSVGenerator(ABC):
     """
     Abstract class used to generate CSV import file(s) for loading samples into a SiriusT3 instrument.
     Subclasses will have different implementations for writing the experimental sections in the generated CSV files.
@@ -214,6 +215,7 @@ class SiriusT3CSVGenerator:
             )
         return "\n".join(lines)
 
+    @abstractmethod
     def generate_experiment_section(self, sample_df: pd.DataFrame) -> str:
         raise NotImplementedError
 

--- a/t3_chomper/formatters.py
+++ b/t3_chomper/formatters.py
@@ -128,7 +128,7 @@ def generate_registration_pka_file(
     merged_df = pd.merge(regi_df, pka_df, how="left", on=sample_col)
 
     # Warn if there are rows with unmatched pKa values
-    missing_row_count = merged_df[pkas_col].isna().count()
+    missing_row_count = merged_df[pkas_col].isna().sum()
     if missing_row_count > 0:
         missing_row_ids = merged_df[merged_df[pkas_col].isna()][sample_col]
         logger.warning(


### PR DESCRIPTION
t3_gencsv script has new arg --filter-file. user can provide a csv file with sample names to filter to in the provided regi file.


Additionally, require regi/filter/pka files to all have the same 'sample' column name, and remove most of the column name adjusting logic. Input files into the t3_gencsv script should be modified outside of the script to have a standard 'sample' column. 