### PR TITLE
Fix TopMost property error in run_gencsv.ps1

### DIFF
--- a/powershell_scripts/run_gencsv.ps1
+++ b/powershell_scripts/run_gencsv.ps1
@@ -8,14 +8,27 @@ $pionTopFolder = "C:\New PION Data"
 # Function to browse for a CSV file
 function Get-CSVFileName {
     param([string]$Title)
-    
+
+    # Create a hidden form to act as owner and ensure TopMost behavior
+    $form = New-Object System.Windows.Forms.Form
+    $form.TopMost = $true
+    $form.StartPosition = 'Manual'
+    $form.Location = New-Object System.Drawing.Point(-2000, -2000)
+    $form.Size = New-Object System.Drawing.Size(1, 1)
+    $form.ShowInTaskbar = $false
+    $form.Show()
+
     $openFileDialog = New-Object System.Windows.Forms.OpenFileDialog
     $openFileDialog.Title = $Title
     $openFileDialog.Filter = "CSV files (*.csv)|*.csv"
     $openFileDialog.InitialDirectory = $pionTopFolder
-	$openFileDialog.TopMost = $true
-    
-    if ($openFileDialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
+
+    $result = $openFileDialog.ShowDialog($form)
+
+    $form.Close()
+    $form.Dispose()
+
+    if ($result -eq [System.Windows.Forms.DialogResult]::OK) {
         return $openFileDialog.FileName
     } else {
         return $null


### PR DESCRIPTION
- Remove invalid TopMost property from OpenFileDialog (doesn't exist)
- Use hidden form as owner for file dialogs to ensure TopMost behavior
- This matches the pattern used in parse_t3r_filenames.ps1
- Fixes RuntimeException: PropertyAssignmentException

OpenFileDialog doesn't support TopMost property. The proper way to make file dialogs appear on top is to pass a TopMost Form as the owner parameter to ShowDialog().